### PR TITLE
fix(server): Passcode not working when no framework is detected.

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -228,10 +228,10 @@ local function isAuthorised(playerId, door, lockpick)
 		if not authorised and door.items then
 			authorised = DoesPlayerHaveItem(player, door.items) or nil
 		end
+	end
 
-		if authorised ~= nil and door.passcode then
-			authorised = door.passcode == lib.callback.await('ox_doorlock:inputPassCode', playerId)
-		end
+	if authorised ~= nil and door.passcode then
+		authorised = door.passcode == lib.callback.await('ox_doorlock:inputPassCode', playerId)
 	end
 
 	return authorised


### PR DESCRIPTION
This commit simply moves the if statement that triggers the passcode callback to outside the if statement checking for player, allowing passcodes to still work when no framework is detected.