### PR TITLE
fix(security): validate teleport permissions

### DIFF
--- a/client/utils.lua
+++ b/client/utils.lua
@@ -219,9 +219,7 @@ end)
 RegisterNUICallback('teleportToDoor', function(id, cb)
 	cb(1)
 	SetNuiFocus(false, false)
-	local doorCoords = doors[id].coords
-	if not doorCoords then return end
-	SetEntityCoords(cache.ped, doorCoords.x, doorCoords.y, doorCoords.z, false, false, false, false)
+	TriggerServerEvent('ox_doorlock:teleportToDoor', id)
 end)
 
 RegisterNUICallback('exit', function(_, cb)

--- a/server/main.lua
+++ b/server/main.lua
@@ -345,6 +345,20 @@ RegisterNetEvent('ox_doorlock:breakLockpick', function()
 	return player and DoesPlayerHaveItem(player, Config.LockpickItems, true)
 end)
 
+RegisterNetEvent('ox_doorlock:teleportToDoor', function(id)
+	if not IsPlayerAceAllowed(source, 'command.doorlock') then
+		return
+	end
+	
+	local door = doors[id]
+	if not door or not door.coords then
+		return
+	end
+	
+	local ped = GetPlayerPed(source)
+	SetEntityCoords(ped, door.coords.x, door.coords.y, door.coords.z, false, false, false, false)
+end)
+
 lib.addCommand('doorlock', {
 	help = locale('create_modify_lock'),
 	params = {


### PR DESCRIPTION
## What this fixes
Previously, users could exploit the teleport functionality via nui_devtools to teleport to any door without proper permissions.

## Changes
- Added `IsPlayerAceAllowed` check for `command.doorlock` permission
- Moved teleport logic to server-side for security

## Testing
- Users without doorlock permissions can no longer teleport
- Users with proper permissions can still teleport normally