### PR TITLE
revert: grid

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -4,22 +4,9 @@ end
 
 if not lib.checkDependency('ox_lib', '3.30.4', true) then return end
 
-local math = require 'glm'
-local doors = {}
-_ENV.doors = doors
-
-
 local function createDoor(door)
-	local oldDoor = doors[door.id]
-
-	if oldDoor then
-		lib.grid.removeEntry(oldDoor)
-	end
-
-	doors[door.id] = door
 	local double = door.doors
 	door.zone = GetLabelText(GetNameOfZone(door.coords.x, door.coords.y, door.coords.z))
-	door.radius = door.maxDistance
 
 	if double then
 		for i = 1, 2 do
@@ -40,58 +27,82 @@ local function createDoor(door)
 			DoorSystemSetAutomaticRate(door.hash, door.doorRate or 10.0, false, false)
 		end
 	end
-
-	lib.grid.addEntry(door)
 end
 
-local nearbyDoors = lib.array:new()
-local nearbyDoorsCount = 0
+local nearbyDoors = {}
 local Entity = Entity
-local ratio = GetAspectRatio(true)
 
 lib.callback('ox_doorlock:getDoors', false, function(data)
-	for _, door in pairs(data) do createDoor(door) end
+	doors = data
+
+	for _, door in pairs(data) do
+		createDoor(door)
+	end
 
 	while true do
+		table.wipe(nearbyDoors)
 		local coords = GetEntityCoords(cache.ped)
-		nearbyDoors = lib.grid.getNearbyEntries(coords)
-		nearbyDoorsCount = #nearbyDoors
-		ratio = GetAspectRatio(true)
 
-		for index = 1, nearbyDoorsCount do
-			local door = nearbyDoors[index]
+		for _, door in pairs(doors) do
 			local double = door.doors
 			door.distance = #(coords - door.coords)
 
 			if double then
-				for i = 1, 2 do
-					local dDoor = double[i]
+				if door.distance < 80 then
+					for i = 1, 2 do
+						if not double[i].entity and IsModelValid(double[i].model) then
+							local entity = GetClosestObjectOfType(double[i].coords.x, double[i].coords.y, double[i].coords.z, 1.0, double[i].model, false, false, false)
 
-					if IsModelValid(dDoor.model) then
-						local entity = not dDoor.entity and GetClosestObjectOfType(dDoor.coords.x, dDoor.coords.y, dDoor.coords.z, 1.0, dDoor.model, false, false, false)
+							if entity ~= 0 then
+								double[i].entity = entity
+								Entity(entity).state.doorId = door.id
+							end
+						end
+					end
 
-						if entity and entity ~= 0 then
-							dDoor.entity = entity
-							Entity(entity).state.doorId = door.id
-						else dDoor.entity = nil end
+					if door.distance < 20 then
+						nearbyDoors[#nearbyDoors + 1] = door
+					end
+				else
+					for i = 1, 2 do
+						double[i].entity = nil
 					end
 				end
-			elseif IsModelValid(door.model) then
-				local entity = not door.entity and GetClosestObjectOfType(door.coords.x, door.coords.y, door.coords.z, 1.0, door.model, false, false, false)
+			elseif door.distance < 80 then
+				if not door.entity and IsModelValid(door.model) then
+					local entity = GetClosestObjectOfType(door.coords.x, door.coords.y, door.coords.z, 1.0, door.model, false, false, false)
 
-				if entity and entity ~= 0 then
-					local dCoords = GetEntityCoords(entity)
-					local min, max = GetModelDimensions(door.model)
-					local center = vec3((min.x + max.x) / 2, (min.y + max.y) / 2, (min.z + max.z) / 2)
-					local heading = GetEntityHeading(entity) * (math.pi / 180)
-					local sin, cos = math.sincos(heading)
-					local rotatedX = cos * center.x - sin * center.y
-					local rotatedY = sin * center.x + cos * center.y
-					door.coords = vec3(dCoords.x + rotatedX, dCoords.y + rotatedY, dCoords.z + center.z)
-					door.entity = entity
+					if entity ~= 0 then
+						local min, max = GetModelDimensions(door.model)
+						local points = {
+							GetOffsetFromEntityInWorldCoords(entity, min.x, min.y, min.z).xy,
+							GetOffsetFromEntityInWorldCoords(entity, min.x, min.y, max.z).xy,
+							GetOffsetFromEntityInWorldCoords(entity, min.x, max.y, max.z).xy,
+							GetOffsetFromEntityInWorldCoords(entity, min.x, max.y, min.z).xy,
+							GetOffsetFromEntityInWorldCoords(entity, max.x, min.y, min.z).xy,
+							GetOffsetFromEntityInWorldCoords(entity, max.x, min.y, max.z).xy,
+							GetOffsetFromEntityInWorldCoords(entity, max.x, max.y, max.z).xy,
+							GetOffsetFromEntityInWorldCoords(entity, max.x, max.y, min.z).xy
+						}
 
-					Entity(entity).state.doorId = door.id
-				else door.entity = nil end
+						local centroid = vec2(0, 0)
+
+						for i = 1, 8 do
+							centroid += points[i]
+						end
+
+						centroid = centroid / 8
+						door.coords = vec3(centroid.x, centroid.y, door.coords.z)
+						door.entity = entity
+						Entity(entity).state.doorId = door.id
+					end
+				end
+
+				if door.distance < 20 then
+					nearbyDoors[#nearbyDoors + 1] = door
+				end
+			elseif door.entity then
+				door.entity = nil
 			end
 		end
 
@@ -103,6 +114,7 @@ RegisterNetEvent('ox_doorlock:setState', function(id, state, source, data)
 	if not doors then return end
 
 	if data then
+		doors[id] = data
 		createDoor(data)
 
 		if NuiHasLoaded then
@@ -182,15 +194,11 @@ RegisterNetEvent('ox_doorlock:editDoorlock', function(id, data)
 	local double = door.doors
 	local doorState = data and data.state or 0
 
-	lib.grid.removeEntry(door)
-
 	if data then
 		data.zone = door.zone or GetLabelText(GetNameOfZone(door.coords.x, door.coords.y, door.coords.z))
-		data.radius = data.maxDistance
 
+		-- hacky method to resolve a bug with "closest door" by forcing a distance recalculation
 		if door.distance < 20 then door.distance = 80 end
-
-		lib.grid.addEntry(data)
 	elseif ClosestDoor?.id == id then
 		ClosestDoor = nil
 	end
@@ -295,14 +303,15 @@ CreateThread(function()
 	local DrawSprite = drawSprite and DrawSprite
 
 	while true do
-		ClosestDoor = nearbyDoors[1]
+		local num = #nearbyDoors
 
-		if nearbyDoorsCount > 0 then
-			for i = 1, nearbyDoorsCount do
+		if num > 0 then
+			local ratio = drawSprite and GetAspectRatio(true)
+			for i = 1, num do
 				local door = nearbyDoors[i]
 
 				if door.distance < door.maxDistance then
-					if door.distance < ClosestDoor.distance then
+					if door.distance < (ClosestDoor?.distance or 10) then
 						ClosestDoor = door
 					end
 
@@ -317,7 +326,7 @@ CreateThread(function()
 					end
 				end
 			end
-		end
+		else ClosestDoor = nil end
 
 		if ClosestDoor and ClosestDoor.distance < ClosestDoor.maxDistance then
 			if Config.DrawTextUI and not ClosestDoor.hideUi and ClosestDoor.state ~= showUI then
@@ -333,7 +342,7 @@ CreateThread(function()
 			showUI = nil
 		end
 
-		Wait(nearbyDoorsCount > 0 and 0 or 500)
+		Wait(num > 0 and 0 or 500)
 	end
 end)
 


### PR DESCRIPTION
Reverts commits https://github.com/CommunityOx/ox_doorlock/commit/7936f153d584163960eaedc15f9c6c9cfa7d9e63, https://github.com/CommunityOx/ox_doorlock/commit/31494947514d440b7d70232606fc90449279dec6 and https://github.com/CommunityOx/ox_doorlock/commit/2abc826012fbe872a8e2831f493d732375c8db08.

These commits contain code that wasn't fully working and tested, and were removed from releases in [the original repo](https://github.com/overextended/ox_doorlock).